### PR TITLE
Add $form_state to _ctools_automodal_get_form_confirm_page() to allow great control for callback

### DIFF
--- a/ctools_automodal.module
+++ b/ctools_automodal.module
@@ -389,8 +389,8 @@ function _ctools_automodal_get_form_redirect_path($modal_options, $form_state) {
  *
  * @see ctools_automodal_get_form()
  */
-function _ctools_automodal_get_form_confirm_page($modal_options) {
-  $confirmation = call_user_func($modal_options['confirm']['callback'], $modal_options['confirm']);
+function _ctools_automodal_get_form_confirm_page($modal_options, $form_state) {
+  $confirmation = call_user_func($modal_options['confirm']['callback'], array($modal_options['confirm'], $form_state));
   $rendered_confirmation = theme('ctools_automodal_confirmation', $confirmation);
   return array($modal_options['confirm']['title'], $rendered_confirmation);
 }
@@ -399,6 +399,7 @@ function _ctools_automodal_get_form_confirm_page($modal_options) {
  * Display a Drupal form using CTools modal or normal page display.
  */
 function ctools_automodal_get_form() {
+
   $args = func_get_args();
   $form_id = array_shift($args);
   $ajax = array_pop($args);
@@ -430,7 +431,7 @@ function ctools_automodal_get_form() {
         $commands[] = ctools_modal_command_dismiss();
       }
       elseif ($modal_options['confirm']) {
-        list($title, $confirm_page) = _ctools_automodal_get_form_confirm_page($modal_options);
+        list($title, $confirm_page) = _ctools_automodal_get_form_confirm_page($modal_options, $form_state);
         $commands[] = ctools_modal_command_display($title, $confirm_page);
       }
 
@@ -514,7 +515,8 @@ function ctools_automodal_page_render($output) {
  *
  * @param array $options
  */
-function ctools_automodal_confirmation_callback($options) {
+function ctools_automodal_confirmation_callback($vars) {
+  $options = array_shift($vars);
   $confirmation = array();
   $confirmation['messages']['#markup'] = theme('status_messages');
   $confirmation['confirmation']['#markup'] = $options['text'];


### PR DESCRIPTION
This commit adds $form_state to the confirm_page() to have greater control over what goes in the callback. In my case I'm submitting a webform and would like to know the nid and sid.

Thanks for the great work on this module.

I've joined those asking for it to get properly added to d.o. http://drupal.org/node/1701192
