### PR TITLE
Fix ctools_automodal_get_modal_options function in paths with wildcards

### DIFF
--- a/ctools_automodal.module
+++ b/ctools_automodal.module
@@ -241,8 +241,16 @@ function ctools_automodal_get_modal_options($path) {
   $modal_options = NULL;
   $ctools_modal_paths = ctools_automodal_get_all_modal_options();
 
-  if (isset($ctools_modal_paths[$path])) {
-    $modal_options = $ctools_modal_paths[$path];
+  $convert_to_regexp = function ($value) { return preg_replace('/%[^\/]*/', '[^/]+', $value); };
+  foreach ($ctools_modal_paths as $ctools_modal_path => $options) {
+    $modal_regexp = '@^' . $convert_to_regexp($ctools_modal_path) . '@';
+    if (preg_match($modal_regexp, $path)) {
+      $modal_options = $options;
+      break;
+    }
+  }
+
+  if (isset($modal_options)) {
     $modal_options += array(
       'style' => '',
       'confirm' => FALSE,


### PR DESCRIPTION
Hi! Few days ago i found out a bug in ctools_automodal when we are using paths with wildcards as modal paths.

If we define a modal path with wildcards like:

``` php
function my_module_modal_paths() {
  $paths = array();

  $paths['my_module/share/%node/%'] = array(
    'style' => 'example-style',
    'close' => TRUE,
  );

  return $paths;
}
```

When we are showing links with these wildcards replaced like 'my_module/share/1/2' ctools_automodal_get_modal_options don't get the modal options defined properly because there isn't a key 'my_module/share/1/2' at $ctools_modal_paths.

To Fix this foreach $ctools_modal_paths i get the regexp and match with the current path, like this we can get the modal options properly and all works fine.

Thanks a lot for this fork.

Regards!
