### PR TITLE
Fixed double confirm option at ctools_automodal_get_modal_options function

### DIFF
--- a/ctools_automodal.module
+++ b/ctools_automodal.module
@@ -247,7 +247,6 @@ function ctools_automodal_get_modal_options($path) {
       'style' => '',
       'confirm' => FALSE,
       'close' => FALSE,
-      'confirm' => FALSE,
       'reload' => FALSE,
       'redirect' => '',
     );


### PR DESCRIPTION
This is a minor fix for confirm option, it is repeated at ctools_automodal_get_modal_options function.

Thanks!